### PR TITLE
Modify Date range and DateTimeRange filters to allow filtering with invalid dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3752,12 +3752,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4807,9 +4807,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -11720,12 +11720,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -12510,9 +12510,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "butterfly-data-filters",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "butterfly-data-filters",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butterfly-data-filters",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "private": false,
   "main": "dist/umd/butterflyDataFilters.js",

--- a/src/__tests__/filterHelper.test.js
+++ b/src/__tests__/filterHelper.test.js
@@ -353,7 +353,6 @@ describe.each([
         [
             {'date': '2020-01-01'},
             {'date': '2020-01-31'},
-            {'date': '2021-01-01'},
         ],
         'DateRange custom with malformed from',
     ],
@@ -375,8 +374,6 @@ describe.each([
             {'date': '2021-01-01'},
         ],
         [
-            {'date': '2020-01-01'},
-            {'date': '2020-01-31'},
             {'date': '2021-01-01'},
         ],
         'DateRange custom with malformed until',
@@ -442,7 +439,6 @@ describe.each([
         [
             {'date': '2020-01-01T00:00'},
             {'date': '2020-01-31T00:10'},
-            {'date': '2021-01-01T00:20'},
         ],
         'DateTimeRange custom with malformed from',
     ],
@@ -464,8 +460,6 @@ describe.each([
             {'date': '2021-01-01T00:03'},
         ],
         [
-            {'date': '2020-01-01T00:01'},
-            {'date': '2020-01-31T00:02'},
             {'date': '2021-01-01T00:03'},
         ],
         'DateTimeRange custom with malformed until',

--- a/src/__tests__/filterHelper.test.js
+++ b/src/__tests__/filterHelper.test.js
@@ -383,6 +383,30 @@ describe.each([
             {
                 'field': 'date',
                 'type': 'dateRange',
+                'value': 'custom',
+                'data': {
+                    'from': '',
+                    'until': '',
+                },
+            },
+        ],
+        [
+            {'date': '2020-01-01'},
+            {'date': '2020-01-31'},
+            {'date': '2021-01-01'},
+        ],
+        [
+            {'date': '2020-01-01'},
+            {'date': '2020-01-31'},
+            {'date': '2021-01-01'},
+        ],
+        'DateRange custom with malformed from and until',
+    ],
+    [
+        [
+            {
+                'field': 'date',
+                'type': 'dateRange',
                 'value': '_any',
             },
         ],
@@ -463,6 +487,30 @@ describe.each([
             {'date': '2021-01-01T00:03'},
         ],
         'DateTimeRange custom with malformed until',
+    ],
+    [
+        [
+            {
+                'field': 'date',
+                'type': 'dateTimeRange',
+                'value': '',
+                'data': {
+                    'from': '',
+                    'until': '',
+                },
+            },
+        ],
+        [
+            {'date': '2020-01-01T00:01'},
+            {'date': '2020-01-31T00:02'},
+            {'date': '2021-01-01T00:03'},
+        ],
+        [
+            {'date': '2020-01-01T00:01'},
+            {'date': '2020-01-31T00:02'},
+            {'date': '2021-01-01T00:03'},
+        ],
+        'DateTimeRange custom with malformed from and until',
     ],
     [
         [

--- a/src/filterHelper.ts
+++ b/src/filterHelper.ts
@@ -133,15 +133,32 @@ export const convertDateRangeValueToBeComparable = (filter: DateFilter) => {
             from = new Date(filter.data.from);
             until = new Date(filter.data.until);
 
-            // Ignore filter if from or until are malformed
+            // Ignore filter if from and until are malformed
             // @ts-ignore next
-            if (isNaN(from) || isNaN(until)) {
+            if (isNaN(from) && isNaN(until)) {
                 return true;
             }
-            until.setHours(23);
-            until.setMinutes(59);
-            until.setSeconds(59);
-            until.setMilliseconds(999);
+
+            // @ts-ignore
+            if (!isNaN(from)) {
+                from.setHours(0);
+                from.setMinutes(0);
+                from.setSeconds(0);
+                from.setMilliseconds(0);
+            } else {
+                from = '';
+            }
+
+            // @ts-ignore
+            if (!isNaN(until)) {
+                until.setHours(23);
+                until.setMinutes(59);
+                until.setSeconds(59);
+                until.setMilliseconds(999);
+            } else {
+                until = '';
+            }
+
             break;
         case ('_any'):
             return true;
@@ -157,7 +174,14 @@ const checkDateRangeFilter = (filter: DateFilter, value: string|number|Date) => 
     if (comparable === true) {
         return true;
     }
-    return (comparable[0] <= value && comparable[1] >= value);
+
+    if (comparable[0] === '') {
+        return comparable[1] >= value;
+    } else if (comparable[1] === '') {
+        return comparable[0] <= value;
+    } else {
+        return (comparable[0] <= value && comparable[1] >= value);
+    }
 };
 
 export const checkDateTimeRangeValueToBeComparable = (filter: DateTimeFilter) => {
@@ -165,12 +189,22 @@ export const checkDateTimeRangeValueToBeComparable = (filter: DateTimeFilter) =>
         return false;
     }
 
-    const from = new Date(filter.data.from);
-    const until = new Date(filter.data.until);
+    let from: string | Date = new Date(filter.data.from);
+    let until: string | Date = new Date(filter.data.until);
 
     // @ts-ignore next
-    if (isNaN(from) || isNaN(until)) {
+    if (isNaN(from) && isNaN(until)) {
         return false;
+    }
+
+    // @ts-ignore next
+    if (isNaN(from)) {
+        from = '';
+    }
+
+    // @ts-ignore next
+    if (isNaN(until)) {
+        until = '';
     }
 
     return [from, until];
@@ -181,7 +215,14 @@ const checkDateTimeRangeFilter = (filter: DateTimeFilter, value: string|number|D
     if (comparable === false) {
         return true;
     }
-    return (comparable[0] <= value && comparable[1] >= value);
+
+    if (comparable[0] === '') {
+        return comparable[1] >= value;
+    } else if (comparable[1] === '') {
+        return comparable[0] <= value;
+    } else {
+        return (comparable[0] <= value && comparable[1] >= value);
+    }
 };
 
 const buildChildFilter = (filter: ChildFilter) => {


### PR DESCRIPTION
Breaking change.

When filtering previously with a custom dateRange filter, or the dateTimeRange filter, the filters would be skipped if either of the from or until fields were invalid dates. 

Now it will only bail if both are invalid dates, and only filter with the valid of the two dates.